### PR TITLE
Drop some IDE usage info in the README; add a debug line for the current path the macro reads from

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Macro annotations are only available in Scala 2.10.x, 2.11.x, and 2.12.x with th
 
         addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
 
-
+In your IDE of choice you will have to explicitly load this compiler plugin most probably. In Eclipse for example, you can do so by providing the full path under the `Xplugin`, found in the advanced Scala compiler preferences; you should have the jar in a path like `~/.ivy2/cache/org.scalamacros/paradise_2.10.4/jars/paradise_2.10.4-2.0.1.jar`. The Avro schema file path might have to be adjusted - check for eventual macro errors.
 
 ####Usage:
 Use the annotations separately, or together like this:
@@ -33,7 +33,7 @@ Use the annotations separately, or together like this:
         case class MyRecord()
 ```
 
-First the fields are added automatically from an Avro Schema in a file, then the methods necessary for de/serialization are generated for you, all at compile time.
+First the fields are added automatically from an Avro Schema in a file, then the methods necessary for de/serialization are generated for you, all at compile time. Notice that the case class cannot have a companion object nor extend any trait or class.
 
 ####Supported data types:  
 

--- a/macros/src/main/scala/avro/scala/macro/annotations/AvroTypeProviderMacro.scala
+++ b/macros/src/main/scala/avro/scala/macro/annotations/AvroTypeProviderMacro.scala
@@ -27,8 +27,9 @@ object AvroTypeProviderMacro {
           val isImmutable: Boolean = {
             !mods.annotations.exists(mod => mod.toString == "new AvroRecord()" | mod.toString =="new AvroRecord(null)")
           }
-           
-          val avroFilePath = FilePathProbe.getPath(c) 
+          
+          println(s"Current path: ${new File(".").getAbsolutePath}")
+          val avroFilePath = FilePathProbe.getPath(c)
           val infile = new File(avroFilePath)
           val schema = FileParser.getSchema(infile)
 


### PR DESCRIPTION
Hello! Really thanks for this plugin, it works for me on 2.10.5, 10 still has the case class field numbers limitation unfortunately :( I've added a few lines to the README and a debug line, you can have a look and modify maybe, just to get an idea.

I've added the debug line because basically I don't really know in my IDE what the directory position is, therefore the relative path I use in the jar-based resources to compile in sbt does not work; don't know if anybody else has tried this in Eclipse, and anyway this is not an issue with your code of course.

Thanks again!