### PR TITLE
Allow schema paths relative to the case class' file

### DIFF
--- a/macros/src/main/scala/avro/scala/macro/annotations/provider/FilePathProbe.scala
+++ b/macros/src/main/scala/avro/scala/macro/annotations/provider/FilePathProbe.scala
@@ -2,6 +2,7 @@ package com.julianpeeters.avro.annotations
 package provider
 
 import scala.reflect.macros.blackbox.Context
+import java.io.File
 
 object FilePathProbe {
 
@@ -10,10 +11,20 @@ object FilePathProbe {
     import c.universe._
     import Flag._
 
-    c.prefix.tree match { 
+    val path = c.prefix.tree match {
       case Apply(_, List(Literal(Constant(x)))) => x.toString
       case _ => c.abort(c.enclosingPosition, "file path not found, annotation argument must be a constant")
     }
+
+    if (new File(path).exists) path else {
+      // Allow paths relative to where the enclosing class is. This allows the working
+      // directory to be different from the project base directory, which is useful
+      // for example with sbt `ProjectRef` referencing a github URL and compiling the
+      // project behind the scenes.
+      val callSite = new File(c.macroApplication.pos.source.file.path).getParent
+      val relative = new File(callSite, path)
+      if (relative.exists) relative.getAbsolutePath else path
+    }
   }
-  
+
 }

--- a/tests/src/test/resources/AvroTypeProviderTestRelativeSchemaFilePath.avsc
+++ b/tests/src/test/resources/AvroTypeProviderTestRelativeSchemaFilePath.avsc
@@ -1,0 +1,15 @@
+{ "type":"record",
+  "name":"Tweet",
+  "namespace":"com.miguno.avro.relative",
+  "fields":[
+    {
+      "name":"username",
+      "type":"string","doc":"Name of the user account on Twitter.com"
+    },
+    {
+      "name":"tweet","type":"string","doc":"The content of the user's Twitter message"
+    },
+    {"name":"timestamp","type":"long","doc":"Unix epoch time in milliseconds"}
+  ],
+  "doc:":"A basic schema for storing Twitter messages"
+}

--- a/tests/src/test/scala/AvroTypeProviderTests/AvroTypeProviderRelativeSchemaFilePathTest.scala
+++ b/tests/src/test/scala/AvroTypeProviderTests/AvroTypeProviderRelativeSchemaFilePathTest.scala
@@ -1,0 +1,23 @@
+package com.miguno.avro.relative
+
+import org.specs2.mutable.Specification
+
+import test.TestUtil
+
+import com.julianpeeters.avro.annotations._
+
+@AvroTypeProvider("../../resources/AvroTypeProviderTestRelativeSchemaFilePath.avsc")
+@AvroRecord
+case class Tweet()
+
+class AvroTypeProviderRelativeSchemaFilePathTest extends Specification {
+
+  "A case class with types provided from a .avsc avro schema file with path relative to the class' position" should {
+    "serialize and deserialize correctly" in {
+      val record1 = Tweet("Achilles", "ow", 2L)
+      val record2 = Tweet("Tortoise", "ho", 3L)
+      val records = List(record1, record2)
+      TestUtil.verifyWriteAndRead(records)
+    }
+  }
+}


### PR DESCRIPTION
We had a situation where we used a `ProjectRef` to reference a github project of our own which used Avro macros, but it couldn't be built under the random directory SBT clones the project into because the paths passed to `AvroTypeProvider` are relative to the working directory, not the project they're included in.

This change allows the path to be relative to the file in which the case class is defined, in case they exist there but not at the default place.