### PR TITLE
Support companion-objects having mixins

### DIFF
--- a/macros/src/main/scala/avro/scala/macro/annotations/AvroTypeProviderMacro.scala
+++ b/macros/src/main/scala/avro/scala/macro/annotations/AvroTypeProviderMacro.scala
@@ -56,9 +56,9 @@ object AvroTypeProviderMacro extends LazyLogging {
             // if there is no preexisiting companion
             case Nil => q"$mods class $name[..$tparams](..${newFields:::first})(...$rest) extends ..$parents { $self => ..$body }"
             // if there is a preexisting companion, include it with the updated classDef
-            case moduleDef @ q"object $moduleName { ..$moduleBody }" :: Nil => {
+            case moduleDef @ q"object $moduleName extends ..$companionParents { ..$moduleBody }" :: Nil => {
               q"""$mods class $name[..$tparams](..${newFields:::first})(...$rest) extends ..$parents { $self => ..$body };
-                object ${name.toTermName} { ..$moduleBody }"""
+                object ${name.toTermName} extends ..$companionParents { ..$moduleBody }"""
             }
           }
         }

--- a/tests/src/test/resources/AvroTypeProviderExtendedCompanionTest00.avsc
+++ b/tests/src/test/resources/AvroTypeProviderExtendedCompanionTest00.avsc
@@ -1,0 +1,19 @@
+{
+  "type": "record",
+  "name": "AvroTypeProviderPreexistingCompanionTest01",
+  "namespace": "test",
+  "fields": [
+    {"name": "message", "type": "string"},
+    {
+      "name": "metaData",
+      "type": {
+        "type": "record",
+        "name": "MetaData",
+        "fields": [
+          {"name": "source", "type": "string"},
+          {"name": "timestamp", "type": "string"}
+        ]
+      }
+    }
+  ]
+}

--- a/tests/src/test/scala/AvroRecordTestClasses.scala
+++ b/tests/src/test/scala/AvroRecordTestClasses.scala
@@ -189,3 +189,10 @@ case class AvroRecordPreexistingCompanionTest00(var x: Int)
 object AvroRecordPreexistingCompanionTest00 {
   val o = 5
 }
+
+trait AvroRecordCompanionTrait {}
+@AvroRecord
+case class AvroRecordPreexistingCompanionTest01(var x: Int)
+object AvroRecordPreexistingCompanionTest01 extends AvroRecordCompanionTrait {
+  val o = 6
+}

--- a/tests/src/test/scala/AvroRecordTests/AvroRecordPreexistingCompanionTest.scala
+++ b/tests/src/test/scala/AvroRecordTests/AvroRecordPreexistingCompanionTest.scala
@@ -20,13 +20,13 @@ class AvroRecordCompanionTest extends Specification {
       val record = AvroRecordPreexistingCompanionTest00(1)
 
       val file = File.createTempFile("AvroRecordPreexistingCompanionTest00", "avro")
-        file.deleteOnExit()
+      file.deleteOnExit()
 
       val userDatumWriter = new SpecificDatumWriter[AvroRecordPreexistingCompanionTest00]
       val dataFileWriter = new DataFileWriter[AvroRecordPreexistingCompanionTest00](userDatumWriter)
-        dataFileWriter.create(record.getSchema(), file);
-        dataFileWriter.append(record);
-        dataFileWriter.close();
+      dataFileWriter.create(record.getSchema(), file);
+      dataFileWriter.append(record);
+      dataFileWriter.close();
 
       val schema = new DataFileReader(file, new GenericDatumReader[GenericRecord]).getSchema
       val userDatumReader = new SpecificDatumReader[AvroRecordPreexistingCompanionTest00](schema)
@@ -34,6 +34,29 @@ class AvroRecordCompanionTest extends Specification {
       val sameRecord = dataFileReader.next()
 
       AvroRecordPreexistingCompanionTest00.o must ===(5)
+      sameRecord must ===(record)
+    }
+  }
+
+  "A case class that has a preexisting companion object with a mixin" should {
+    "serialize and deserialize correctly" in {
+      val record = AvroRecordPreexistingCompanionTest01(1)
+
+      val file = File.createTempFile("AvroRecordPreexistingCompanionTest01", "avro")
+      file.deleteOnExit()
+
+      val userDatumWriter = new SpecificDatumWriter[AvroRecordPreexistingCompanionTest01]
+      val dataFileWriter = new DataFileWriter[AvroRecordPreexistingCompanionTest01](userDatumWriter)
+      dataFileWriter.create(record.getSchema(), file);
+      dataFileWriter.append(record);
+      dataFileWriter.close();
+
+      val schema = new DataFileReader(file, new GenericDatumReader[GenericRecord]).getSchema
+      val userDatumReader = new SpecificDatumReader[AvroRecordPreexistingCompanionTest01](schema)
+      val dataFileReader = new DataFileReader[AvroRecordPreexistingCompanionTest01](file, userDatumReader)
+      val sameRecord = dataFileReader.next()
+
+      AvroRecordPreexistingCompanionTest01.o must ===(6)
       sameRecord must ===(record)
     }
   }

--- a/tests/src/test/scala/AvroTypeProviderTestClasses.scala
+++ b/tests/src/test/scala/AvroTypeProviderTestClasses.scala
@@ -343,6 +343,14 @@ object AvroTypeProviderPreexistingCompanionTest00 {
   val o = 5
 }
 
+trait AvroTypeProviderTestCompanionTrait {}
+@AvroTypeProvider("tests/src/test/resources/AvroTypeProviderExtendedCompanionTest00.avsc")
+@AvroRecord
+case class AvroTypeProviderPreexistingCompanionTest01()
+object AvroTypeProviderPreexistingCompanionTest01 extends AvroTypeProviderTestCompanionTrait {
+  val o = 6
+}
+
 // nested record from schema file instead of nested record from .avro file
 @AvroTypeProvider("tests/src/test/resources/AvroTypeProviderTestNestedSchemaFile.avsc")
 @AvroRecord

--- a/tests/src/test/scala/AvroTypeProviderTests/AvroTypeProviderPreexistingCompanionTest.scala
+++ b/tests/src/test/scala/AvroTypeProviderTests/AvroTypeProviderPreexistingCompanionTest.scala
@@ -34,4 +34,28 @@ class AvroTypeProviderCompanionTest extends Specification {
       sameRecord must ===(record)
     }
   }
+
+  "A case class that has a preexisting companion object with mixins" should {
+    "serialize and deserialize correctly" in {
+
+      val record = AvroRecordPreexistingCompanionTest01(1)
+
+      val file = File.createTempFile("AvroRecordPreexistingCompanionTest01", "avsc")
+      file.deleteOnExit()
+
+      val userDatumWriter = new SpecificDatumWriter[AvroRecordPreexistingCompanionTest01]
+      val dataFileWriter = new DataFileWriter[AvroRecordPreexistingCompanionTest01](userDatumWriter)
+      dataFileWriter.create(record.getSchema(), file);
+      dataFileWriter.append(record);
+      dataFileWriter.close();
+
+      val schema = new DataFileReader(file, new GenericDatumReader[GenericRecord]).getSchema
+      val userDatumReader = new SpecificDatumReader[AvroRecordPreexistingCompanionTest01](schema)
+      val dataFileReader = new DataFileReader[AvroRecordPreexistingCompanionTest01](file, userDatumReader)
+      val sameRecord = dataFileReader.next()
+      AvroRecordPreexistingCompanionTest01.o must ===(6)
+
+      sameRecord must ===(record)
+    }
+  }
 }


### PR DESCRIPTION
When the companion object has an extends... clause, the "tail match ..." triggered a scala.MatchError for List(<moduleDef>).  

Augmented to support List( moduleDef @ ...), and propagate the companion's extends clause into the rewritten companion definitions.