### PR TITLE
FIX: Different namespace in referenced class didn't compile

### DIFF
--- a/tests/src/test/resources/AvroTypeProviderTestDifferentNamespace.avsc
+++ b/tests/src/test/resources/AvroTypeProviderTestDifferentNamespace.avsc
@@ -1,0 +1,25 @@
+[
+{ "type":"record",
+  "name":"Person",
+  "namespace":"com.miguno.avro.differentns",
+  "fields":[
+    {"name":"id", "type":"long"},
+    {"name":"name","type":"string"}
+  ],
+  "doc:":"A basic schema for a user, to be reused across namespaces."
+},
+{ "type":"record",
+  "name":"Tweet",
+  "namespace":"com.miguno.avro.differentns.twitter",
+  "fields":[
+    {
+      "name":"author",
+      "type":"com.miguno.avro.differentns.Person"
+    },
+    {
+      "name":"text", "type":"string"
+    }
+  ],
+  "doc:":"A basic schema for storing Twitter messages"
+}
+]

--- a/tests/src/test/scala/AvroTypeProviderTests/AvroTypeProviderDifferentNamespaceTest.scala
+++ b/tests/src/test/scala/AvroTypeProviderTests/AvroTypeProviderDifferentNamespaceTest.scala
@@ -1,0 +1,28 @@
+package com.miguno.avro.differentns
+
+import org.specs2.mutable.Specification
+
+import test.TestUtil
+
+import com.julianpeeters.avro.annotations._
+
+@AvroTypeProvider("tests/src/test/resources/AvroTypeProviderTestDifferentNamespace.avsc")
+@AvroRecord
+case class Person()
+
+// Nested namespace
+package twitter {
+  @AvroTypeProvider("tests/src/test/resources/AvroTypeProviderTestDifferentNamespace.avsc")
+  @AvroRecord
+  case class Tweet()
+}
+
+class AvroTypeProviderDifferentNamespaceTest extends Specification {
+
+  "A case class with types provided from a .avsc avro schema file referencing another class in a different namespace" should {
+    "serialize and deserialize correctly" in {
+      val record = twitter.Tweet(Person(id = 1, name = "John"), "Yo!")
+      TestUtil.verifyWriteAndRead(List(record))
+    }
+  }
+}


### PR DESCRIPTION
Fixes the case when a record references another one in a different namespace, higher in the hierarchy, some generic DTO for example. The code was assuming that if the referring class has a namespace then the other one will have the same. 

This came out with top level union schemas.